### PR TITLE
update references from original skyscrapr repo with pinecone-io

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,3 @@ jobs:
           TF_ACC: "1"
         run: go test -race -covermode=atomic -coverprofile=coverage.out -v ./pinecone/provider/
         timeout-minutes: 10
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,0 @@
-## 0.1.0 (Unreleased)
-
-FEATURES:

--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
 # Terraform Pinecone Provider
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/skyscrapr/terraform-provider-pinecone.svg)](https://pkg.go.dev/github.com/skyscrapr/terraform-provider-pinecone)
-[![Go Report Card](https://goreportcard.com/badge/github.com/skyscrapr/terraform-provider-pinecone)](https://goreportcard.com/report/github.com/skyscrapr/terraform-provider-pinecone)
-[![codecov](https://codecov.io/gh/skyscrapr/terraform-provider-pinecone/graph/badge.svg?token=qobuIzQPuM)](https://codecov.io/gh/skyscrapr/terraform-provider-pinecone)
-![Github Actions Workflow](https://github.com/skyscrapr/terraform-provider-pinecone/actions/workflows/test.yml/badge.svg)
-![GitHub release (latest by date)](https://img.shields.io/github/v/release/skyscrapr/terraform-provider-pinecone)
-![License](https://img.shields.io/dub/l/vibe-d.svg)
+[![Go Reference](https://pkg.go.dev/badge/github.com/pinecone-io/terraform-provider-pinecone.svg)](https://pkg.go.dev/github.com/pinecone-io/terraform-provider-pinecone)
+[![Go Report Card](https://goreportcard.com/badge/github.com/pinecone-io/terraform-provider-pinecone)](https://goreportcard.com/report/github.com/pinecone-io/terraform-provider-pinecone)
+![Github Actions Workflow](https://github.com/pinecone-io/terraform-provider-pinecone/actions/workflows/test.yml/badge.svg)
+![GitHub release (latest by date)](https://img.shields.io/github/v/release/pinecone-io/terraform-provider-pinecone)
 
 The Terraform Pinecone Provider allows Terraform to manage Pinecone resources.
 
-Please note: We take Terraform's security and our users' trust very seriously. If you believe you have found a security issue in the Terraform Pinecone Provider, please responsibly disclose it by contacting us.
+Please note: We take Terraform's security and our users' trust very seriously. If you believe you have found a security
+issue in the Terraform Pinecone Provider, please responsibly disclose it by contacting us.
 
 ## Requirements
 
@@ -18,17 +17,17 @@ Please note: We take Terraform's security and our users' trust very seriously. I
 
 ## Installing the Provider
 
-The provider is registered in the official [terraform registry](https://registry.terraform.io/providers/skyscrapr/pinecone/latest) 
+The provider is registered in the official [terraform registry](https://registry.terraform.io/providers/pinecone-io/pinecone/latest) 
 
 This enables the provider to be auto-installed when you run ```terraform init```
 
-You can also download the latest binary for your target platform from the [releases](https://github.com/skyscrapr/terraform-provider-pinecone/releases) tab.
+You can also download the latest binary for your target platform from the [releases](https://github.com/pinecone-io/terraform-provider-pinecone/releases) tab.
 
 ## Building the Provider
 
 - Clone the repo:
     ```sh
-    $ git clone https://github.com/skyscrapr/terraform-provider-pinecone
+    $ git clone https://github.com/pinecone-io/terraform-provider-pinecone
     ```
 
 - Build the provider: (NOTE: the install directory will be set accoring to GOPATH environment variable)
@@ -43,7 +42,7 @@ You can enable the provider in your terraform configurtion by add the folowing:
 terraform {
   required_providers {
     openai = {
-      source = "skyscrapr/pinecone"
+      source = "pinecone-io/pinecone"
     }
   }
 }
@@ -55,12 +54,20 @@ You can configure the Pinecone client using environment variables to avoid setti
 
 ## Documentation
 
-Documentation can be found on the [Terraform Registry](https://registry.terraform.io/providers/skyscrapr/pinecone/latest). 
+Documentation can be found on the [Terraform Registry](https://registry.terraform.io/providers/pinecone-io/pinecone/latest). 
 
 ## Examples
 
-Please see the [examples](https://github.com/skyscrapr/terraform-provider-pinecone/examples) for example usage.
+Please see the [examples](https://github.com/pinecone-io/terraform-provider-pinecone/examples) for example usage.
 
 ## Support
 
 Please raise an issue for any support related requirements.
+
+## Contributing
+
+Thank you to [skyscrapr](https://github.com/skyscrapr/) for developing this Terraform Provider. The original repo can be
+found at [skyscrapr/terraform-provider-pinecone](https://github.com/skyscrapr/terraform-provider-pinecone). He continues
+to be the primary developer of this codebase.
+
+We welcome all contributions. Please do not hesitate on filing an issue or contributing a PR for improvements.

--- a/docs/data-sources/collection.md
+++ b/docs/data-sources/collection.md
@@ -16,7 +16,7 @@ Collection data source
 terraform {
   required_providers {
     pinecone = {
-      source = "skyscrapr/pinecone"
+      source = "pinecone-io/pinecone"
     }
   }
 }

--- a/docs/data-sources/collections.md
+++ b/docs/data-sources/collections.md
@@ -16,7 +16,7 @@ Collections data source
 terraform {
   required_providers {
     pinecone = {
-      source = "skyscrapr/pinecone"
+      source = "pinecone-io/pinecone"
     }
   }
 }

--- a/docs/data-sources/index.md
+++ b/docs/data-sources/index.md
@@ -16,7 +16,7 @@ Index data source
 terraform {
   required_providers {
     pinecone = {
-      source = "skyscrapr/pinecone"
+      source = "pinecone-io/pinecone"
     }
   }
 }

--- a/docs/data-sources/indexes.md
+++ b/docs/data-sources/indexes.md
@@ -16,7 +16,7 @@ Indexes data source
 terraform {
   required_providers {
     pinecone = {
-      source = "skyscrapr/pinecone"
+      source = "pinecone-io/pinecone"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ description: |-
 terraform {
   required_providers {
     pinecone = {
-      source = "skyscrapr/pinecone"
+      source = "pinecone-io/pinecone"
     }
   }
 }

--- a/docs/resources/collection.md
+++ b/docs/resources/collection.md
@@ -16,7 +16,7 @@ Collection resource
 terraform {
   required_providers {
     pinecone = {
-      source = "skyscrapr/pinecone"
+      source = "pinecone-io/pinecone"
     }
   }
 }

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -16,7 +16,7 @@ Index resource
 terraform {
   required_providers {
     pinecone = {
-      source = "skyscrapr/pinecone"
+      source = "pinecone-io/pinecone"
     }
   }
 }

--- a/examples/data-sources/pinecone_collection/data-source.tf
+++ b/examples/data-sources/pinecone_collection/data-source.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     pinecone = {
-      source = "skyscrapr/pinecone"
+      source = "pinecone-io/pinecone"
     }
   }
 }

--- a/examples/data-sources/pinecone_collections/data-source.tf
+++ b/examples/data-sources/pinecone_collections/data-source.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     pinecone = {
-      source = "skyscrapr/pinecone"
+      source = "pinecone-io/pinecone"
     }
   }
 }

--- a/examples/data-sources/pinecone_index/data-source.tf
+++ b/examples/data-sources/pinecone_index/data-source.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     pinecone = {
-      source = "skyscrapr/pinecone"
+      source = "pinecone-io/pinecone"
     }
   }
 }

--- a/examples/data-sources/pinecone_indexes/data-source.tf
+++ b/examples/data-sources/pinecone_indexes/data-source.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     pinecone = {
-      source = "skyscrapr/pinecone"
+      source = "pinecone-io/pinecone"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     pinecone = {
-      source = "skyscrapr/pinecone"
+      source = "pinecone-io/pinecone"
     }
   }
 }

--- a/examples/resources/pinecone_collection/resource.tf
+++ b/examples/resources/pinecone_collection/resource.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     pinecone = {
-      source = "skyscrapr/pinecone"
+      source = "pinecone-io/pinecone"
     }
   }
 }

--- a/examples/resources/pinecone_index/resource.tf
+++ b/examples/resources/pinecone_index/resource.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     pinecone = {
-      source = "skyscrapr/pinecone"
+      source = "pinecone-io/pinecone"
     }
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/skyscrapr/terraform-provider-pinecone
+module github.com/pinecone-io/terraform-provider-pinecone
 
 go 1.21.1
 
@@ -85,5 +85,3 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
 
-// Use below for local development
-// replace github.com/skyscrapr/pinecone-sdk-go => ../pinecone-sdk-go

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	"github.com/skyscrapr/terraform-provider-pinecone/pinecone/provider"
+	"github.com/pinecone-io/terraform-provider-pinecone/pinecone/provider"
 )
 
 // Run "go generate" to format example terraform files and generate the docs for the registry/website
@@ -38,7 +38,7 @@ func main() {
 	flag.Parse()
 
 	opts := providerserver.ServeOpts{
-		Address: "registry.terraform.io/skyscrapr/pinecone",
+		Address: "registry.terraform.io/pinecone/pinecone",
 		Debug:   debug,
 	}
 

--- a/pinecone/provider/collection_data_source.go
+++ b/pinecone/provider/collection_data_source.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/skyscrapr/terraform-provider-pinecone/pinecone/models"
+	"github.com/pinecone-io/terraform-provider-pinecone/pinecone/models"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/pinecone/provider/collection_resource.go
+++ b/pinecone/provider/collection_resource.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/pinecone-io/go-pinecone/pinecone"
-	"github.com/skyscrapr/terraform-provider-pinecone/pinecone/models"
+	"github.com/pinecone-io/terraform-provider-pinecone/pinecone/models"
 )
 
 const (

--- a/pinecone/provider/collections_data_source.go
+++ b/pinecone/provider/collections_data_source.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/skyscrapr/terraform-provider-pinecone/pinecone/models"
+	"github.com/pinecone-io/terraform-provider-pinecone/pinecone/models"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/pinecone/provider/index_data_source.go
+++ b/pinecone/provider/index_data_source.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/skyscrapr/terraform-provider-pinecone/pinecone/models"
+	"github.com/pinecone-io/terraform-provider-pinecone/pinecone/models"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/pinecone/provider/index_resource.go
+++ b/pinecone/provider/index_resource.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/pinecone-io/go-pinecone/pinecone"
-	"github.com/skyscrapr/terraform-provider-pinecone/pinecone/models"
+	"github.com/pinecone-io/terraform-provider-pinecone/pinecone/models"
 )
 
 const (

--- a/pinecone/provider/indexes_data_source.go
+++ b/pinecone/provider/indexes_data_source.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/skyscrapr/terraform-provider-pinecone/pinecone/models"
+	"github.com/pinecone-io/terraform-provider-pinecone/pinecone/models"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.


### PR DESCRIPTION
Initial pass at adopting skyscrapr/terraform-provider-pinecone to the official pinecone-io/terraform-provider-pinecone repo.