### PR TITLE
update docs to not require environment for provider init

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You can enable the provider in your terraform configurtion by add the folowing:
 ```terraform
 terraform {
   required_providers {
-    openai = {
+    pinecone = {
       source = "pinecone-io/pinecone"
     }
   }

--- a/docs/data-sources/collection.md
+++ b/docs/data-sources/collection.md
@@ -22,7 +22,6 @@ terraform {
 }
 
 provider "pinecone" {
-  environment = "us-west4-gcp"
   # api_key = set via PINECONE_API_KEY env variable
 }
 

--- a/docs/data-sources/collections.md
+++ b/docs/data-sources/collections.md
@@ -22,7 +22,6 @@ terraform {
 }
 
 provider "pinecone" {
-  environment = "us-west4-gcp"
   # api_key = set via PINECONE_API_KEY env variable
 }
 

--- a/docs/data-sources/index.md
+++ b/docs/data-sources/index.md
@@ -22,7 +22,6 @@ terraform {
 }
 
 provider "pinecone" {
-  environment = "us-west4-gcp"
   # api_key = set via PINECONE_API_KEY env variable
 }
 

--- a/docs/data-sources/indexes.md
+++ b/docs/data-sources/indexes.md
@@ -22,7 +22,6 @@ terraform {
 }
 
 provider "pinecone" {
-  environment = "gcp-starter"
   # api_key = set via PINECONE_API_KEY env variable
 }
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,6 @@ terraform {
 }
 
 provider "pinecone" {
-  environment = "us-west4-gcp"
   # api_key = set via PINECONE_API_KEY env variable
 }
 ```

--- a/docs/resources/collection.md
+++ b/docs/resources/collection.md
@@ -22,7 +22,6 @@ terraform {
 }
 
 provider "pinecone" {
-  environment = "us-west4-gcp"
   # api_key = set via PINECONE_API_KEY env variable
 }
 

--- a/examples/data-sources/pinecone_collection/data-source.tf
+++ b/examples/data-sources/pinecone_collection/data-source.tf
@@ -7,7 +7,6 @@ terraform {
 }
 
 provider "pinecone" {
-  environment = "us-west4-gcp"
   # api_key = set via PINECONE_API_KEY env variable
 }
 

--- a/examples/data-sources/pinecone_collections/data-source.tf
+++ b/examples/data-sources/pinecone_collections/data-source.tf
@@ -7,7 +7,6 @@ terraform {
 }
 
 provider "pinecone" {
-  environment = "us-west4-gcp"
   # api_key = set via PINECONE_API_KEY env variable
 }
 

--- a/examples/data-sources/pinecone_index/data-source.tf
+++ b/examples/data-sources/pinecone_index/data-source.tf
@@ -7,7 +7,6 @@ terraform {
 }
 
 provider "pinecone" {
-  environment = "us-west4-gcp"
   # api_key = set via PINECONE_API_KEY env variable
 }
 

--- a/examples/data-sources/pinecone_indexes/data-source.tf
+++ b/examples/data-sources/pinecone_indexes/data-source.tf
@@ -7,7 +7,6 @@ terraform {
 }
 
 provider "pinecone" {
-  environment = "gcp-starter"
   # api_key = set via PINECONE_API_KEY env variable
 }
 

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -7,6 +7,5 @@ terraform {
 }
 
 provider "pinecone" {
-  environment = "us-west4-gcp"
   # api_key = set via PINECONE_API_KEY env variable
 }

--- a/examples/resources/pinecone_collection/resource.tf
+++ b/examples/resources/pinecone_collection/resource.tf
@@ -7,7 +7,6 @@ terraform {
 }
 
 provider "pinecone" {
-  environment = "us-west4-gcp"
   # api_key = set via PINECONE_API_KEY env variable
 }
 


### PR DESCRIPTION
Fixes documentation. The provider no longer requires an `environment` to initialize.
