### PR TITLE
Convert `pods` attribute to read only

### DIFF
--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -76,10 +76,13 @@ Required:
 Optional:
 
 - `metadata_config` (Attributes) Configuration for the behavior of Pinecone's internal metadata index. By default, all metadata is indexed; when metadata_config is present, only specified metadata fields are indexed. These configurations are only valid for use with pod-based indexes. (see [below for nested schema](#nestedatt--spec--pod--metadata_config))
-- `pods` (Number) The number of pods to be used in the index. This should be equal to shards x replicas.'
 - `replicas` (Number) The number of replicas. Replicas duplicate your index. They provide higher availability and throughput. Replicas can be scaled up or down as your needs change.
 - `shards` (Number) The number of shards. Shards split your data across multiple pods so you can fit more data into an index.
 - `source_collection` (String) The name of the collection to create an index from.
+
+Read-Only:
+
+- `pods` (Number) The number of pods to be used in the index. This should be equal to shards x replicas.'
 
 <a id="nestedatt--spec--pod--metadata_config"></a>
 ### Nested Schema for `spec.pod.metadata_config`

--- a/pinecone/provider/index_resource.go
+++ b/pinecone/provider/index_resource.go
@@ -117,9 +117,7 @@ func (r *IndexResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 							},
 							"pods": schema.Int64Attribute{
 								MarkdownDescription: "The number of pods to be used in the index. This should be equal to shards x replicas.'",
-								Optional:            true,
 								Computed:            true,
-								Default:             int64default.StaticInt64(1),
 							},
 							"metadata_config": schema.SingleNestedAttribute{
 								Description: "Configuration for the behavior of Pinecone's internal metadata index. By default, all metadata is indexed; when metadata_config is present, only specified metadata fields are indexed. These configurations are only valid for use with pod-based indexes.",
@@ -214,7 +212,6 @@ func (r *IndexResource) Create(ctx context.Context, req resource.CreateRequest, 
 			PodType:     spec.Pod.PodType.ValueString(),
 			Shards:      int32(spec.Pod.ShardCount.ValueInt64()),
 			Replicas:    int32(spec.Pod.Replicas.ValueInt64()),
-			// SourceCollection: spec.Pod.SourceCollection.ValueStringPointer(),
 		}
 
 		if !spec.Pod.SourceCollection.IsUnknown() {

--- a/pinecone/provider/index_resource_test.go
+++ b/pinecone/provider/index_resource_test.go
@@ -51,15 +51,15 @@ func TestAccIndexResource_pod_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccIndexResourceConfig_pod_basic(rName, "1", "1"),
+				Config: testAccIndexResourceConfig_pod_basic(rName, "2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("pinecone_index.test", "id", rName),
 					resource.TestCheckResourceAttr("pinecone_index.test", "name", rName),
 					resource.TestCheckResourceAttr("pinecone_index.test", "dimension", "1536"),
 					resource.TestCheckResourceAttr("pinecone_index.test", "metric", "cosine"),
 					resource.TestCheckResourceAttr("pinecone_index.test", "spec.pod.pod_type", "s1.x1"),
-					resource.TestCheckResourceAttr("pinecone_index.test", "spec.pod.replicas", "1"),
-					resource.TestCheckResourceAttr("pinecone_index.test", "spec.pod.pods", "1"),
+					resource.TestCheckResourceAttr("pinecone_index.test", "spec.pod.replicas", "2"),
+					resource.TestCheckResourceAttr("pinecone_index.test", "spec.pod.pods", "2"),
 					// resource.TestCheckNoResourceAttr("pinecone_index.test", "metadata_config"),
 					// resource.TestCheckNoResourceAttr("pinecone_index.test", "source_collection"),
 				),
@@ -134,7 +134,7 @@ resource "pinecone_index" "test" {
 `, name)
 }
 
-func testAccIndexResourceConfig_pod_basic(name string, replicas string, pods string) string {
+func testAccIndexResourceConfig_pod_basic(name string, replicas string) string {
 	return fmt.Sprintf(`
 provider "pinecone" {
 }
@@ -146,11 +146,10 @@ resource "pinecone_index" "test" {
 			environment = "us-west4-gcp"
 			pod_type = "s1.x1"
 			replicas = %q
-			pods = %q
 		}
 	}
 }
-`, name, replicas, pods)
+`, name, replicas)
 }
 
 func testAccIndexResourceConfig_dimension(name string, dimension string) string {


### PR DESCRIPTION
## Problem

convert `pods` attribute to read only.

## Solution

I created the original implementation without fully understanding the pods attribute was calculated.
Converted the attribute to a computed, read-only attribute. 
Updated the test to use multiple replicas to test for correct behaviour.

## Type of Change

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Output

Running tool: /opt/homebrew/bin/go test -timeout 300s -run ^TestAccIndexResource_pod_basic$ github.com/pinecone-io/terraform-provider-pinecone/pinecone/provider

ok  	github.com/pinecone-io/terraform-provider-pinecone/pinecone/provider	28.504s


