### PR TITLE
No default value for required attribute dimension

### DIFF
--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -42,12 +42,12 @@ resource "pinecone_index" "test" {
 
 ### Required
 
+- `dimension` (Number) The dimensions of the vectors to be inserted in the index
 - `name` (String) The name of the index to be created. The maximum length is 45 characters.
 - `spec` (Attributes) Spec (see [below for nested schema](#nestedatt--spec))
 
 ### Optional
 
-- `dimension` (Number) The dimensions of the vectors to be inserted in the index
 - `metric` (String) The distance metric to be used for similarity search. You can use 'euclidean', 'cosine', or 'dotproduct'.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 

--- a/examples/data-sources/pinecone_collection/data-source.tf
+++ b/examples/data-sources/pinecone_collection/data-source.tf
@@ -12,6 +12,7 @@ provider "pinecone" {
 
 resource "pinecone_index" "test" {
   name = "tftestindex"
+  dimension = 10
   spec = {
     pod = {
       environment = "us-west4-gcp"

--- a/examples/data-sources/pinecone_index/data-source.tf
+++ b/examples/data-sources/pinecone_index/data-source.tf
@@ -12,6 +12,7 @@ provider "pinecone" {
 
 resource "pinecone_index" "test" {
   name = "tftestindex"
+  dimension = 10
   spec = {
     serverless = {
       cloud  = "aws"

--- a/examples/data-sources/pinecone_indexes/data-source.tf
+++ b/examples/data-sources/pinecone_indexes/data-source.tf
@@ -12,6 +12,7 @@ provider "pinecone" {
 
 resource "pinecone_index" "test" {
   name = "tftestindex"
+  dimension = 10
   spec = {
     serverless = {
       cloud  = "aws"

--- a/examples/resources/pinecone_collection/resource.tf
+++ b/examples/resources/pinecone_collection/resource.tf
@@ -12,6 +12,7 @@ provider "pinecone" {
 
 resource "pinecone_index" "test" {
   name = "tftestindex"
+  dimension = 10
   spec = {
     pod = {
       environment = "us-west4-gcp"

--- a/examples/resources/pinecone_index/resource.tf
+++ b/examples/resources/pinecone_index/resource.tf
@@ -7,12 +7,12 @@ terraform {
 }
 
 provider "pinecone" {
-  environment = "us-west4-gcp"
   # api_key = set via PINECONE_API_KEY env variable
 }
 
 resource "pinecone_index" "test" {
   name = "tftestindex"
+  dimension = 10
   spec = {
     serverless = {
       cloud  = "aws"

--- a/pinecone/provider/index_resource.go
+++ b/pinecone/provider/index_resource.go
@@ -67,9 +67,7 @@ func (r *IndexResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 			},
 			"dimension": schema.Int64Attribute{
 				MarkdownDescription: "The dimensions of the vectors to be inserted in the index",
-				Optional:            true,
-				Computed:            true,
-				Default:             int64default.StaticInt64(1536),
+				Required:            true,
 				Validators: []validator.Int64{
 					int64validator.AtLeast(1),
 				},

--- a/pinecone/provider/index_resource_test.go
+++ b/pinecone/provider/index_resource_test.go
@@ -124,6 +124,7 @@ provider "pinecone" {
 
 resource "pinecone_index" "test" {
   name = %q
+  dimension = 1536
   spec = {
 	serverless = {
 		cloud = "aws"
@@ -141,6 +142,7 @@ provider "pinecone" {
 
 resource "pinecone_index" "test" {
 	name = %q
+	dimension = 1536
 	spec = {
 		pod = {
 			environment = "us-west4-gcp"


### PR DESCRIPTION
## Problem

No default value for required attribute `dimension`

## Solution

Modify the schema to require dimension attribute and avoid setting a default value if not supplied.

## Type of Change

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Tests are passing:

Running tool: /opt/homebrew/bin/go test -timeout 300s -run ^(TestAccIndexResource_serverless|TestAccIndexResource_pod_basic|TestAccIndexResource_dimension)$ github.com/pinecone-io/terraform-provider-pinecone/pinecone/provider

ok  	github.com/pinecone-io/terraform-provider-pinecone/pinecone/provider	70.625s
