### PR TITLE
remove index from state on read 404

### DIFF
--- a/pinecone/provider/index_resource.go
+++ b/pinecone/provider/index_resource.go
@@ -296,7 +296,11 @@ func (r *IndexResource) Read(ctx context.Context, req resource.ReadRequest, resp
 
 	index, err := r.client.DescribeIndex(ctx, data.Id.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("Failed to describe index", err.Error())
+		if err.Error() == fmt.Sprintf("failed to describe idx: Resource %s not found", data.Id.ValueString()) {
+			resp.State.RemoveResource(ctx)
+		} else {
+			resp.Diagnostics.AddError("Failed to describe index", err.Error())
+		}
 		return
 	}
 


### PR DESCRIPTION
On `IndexResource#Read` if the client returns a 404, the correct thing to do is remove it from the response state. 

Note, this uses the error message from the Go SDK to determine not found. The SDK should be fixed upstream. See https://github.com/pinecone-io/go-pinecone/issues/17

fixes #6 
