### PR TITLE
Add disappears acceptance test for index resource.

### DIFF
--- a/pinecone/provider/common_test.go
+++ b/pinecone/provider/common_test.go
@@ -5,11 +5,23 @@ package provider
 
 import (
 	"context"
+	"os"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/pinecone-io/go-pinecone/pinecone"
-	"testing"
 )
+
+// NewTestClient returns a new Pinecone API client instance
+// to be used in acceptance tests.
+func NewTestClient() (*pinecone.Client, error) {
+	apiKey := os.Getenv("PINECONE_API_KEY")
+
+	return pinecone.NewClient(pinecone.NewClientParams{
+		ApiKey: apiKey,
+	})
+}
 
 func TestDatasource_Configure(t *testing.T) {
 	// Create a test *pinecone.Client

--- a/pinecone/provider/index_resource.go
+++ b/pinecone/provider/index_resource.go
@@ -310,8 +310,6 @@ func (r *IndexResource) Create(ctx context.Context, req resource.CreateRequest, 
 		return
 	}
 
-	// resp.Diagnostics.Append(data.Read(ctx, index)...)
-
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -358,7 +356,9 @@ func (r *IndexResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 
 	err := r.client.DeleteIndex(ctx, data.Name.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("Failed to delete index", err.Error())
+		if !strings.Contains(err.Error(), "not found") {
+			resp.Diagnostics.AddError("Failed to delete index", err.Error())
+		}
 		return
 	}
 

--- a/pinecone/provider/index_resource_test.go
+++ b/pinecone/provider/index_resource_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"


### PR DESCRIPTION
## Problem

Add disappears test for index to handle scenarios where the index is deleted manually from the console.

## Solution

There is a common pattern use in the terraform provider for AWS: [docs](https://hashicorp.github.io/terraform-provider-aws/running-and-writing-acceptance-tests/#disappears-acceptance-tests)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Test output : 
Running tool: /opt/homebrew/bin/go test -timeout 300s -run ^TestAccIndexResource_dimension$ github.com/pinecone-io/terraform-provider-pinecone/pinecone/provider

ok  	github.com/pinecone-io/terraform-provider-pinecone/pinecone/provider	12.636s

