### PR TITLE
Update `.goreleaser.yml` to `version: 2` 

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,6 @@
 # Visit https://goreleaser.com for documentation on how to customize this
 # behavior.
+version: 2
 before:
   hooks:
     # this is just an example and not a requirement for provider building/publishing
@@ -56,5 +57,3 @@ release:
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
-changelog:
-  skip: true


### PR DESCRIPTION
## Problem
Our release process was failing due to problems with our `.goreleaser.yml` file: https://github.com/pinecone-io/terraform-provider-pinecone/actions/runs/10744450678/job/29801435249

## Solution

- Add `version: 2`
- Remove invalid `changelog` config

Validated things locally using `goreleaser check`:

![Screenshot 2024-09-06 at 4 59 34 PM](https://github.com/user-attachments/assets/9e64768f-7df2-4192-a908-4fa256eda1bc)

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
Merge this to main then re-push the tag to re-run the release flow.
