### PR TITLE
Bump Terraform version range in acceptance tests

### DIFF
--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   authorize:
-    environment:
+    environment: |
       ${{ github.event_name == 'pull_request_target' &&
       github.event.pull_request.head.repo.full_name != github.repository &&
       'external' || 'internal' }}
@@ -25,13 +25,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # list whatever Terraform versions here you would like to support
         terraform:
-          - '1.0.*'
-          - '1.1.*'
-          - '1.2.*'
-          - '1.3.*'
           - '1.4.*'
+          - '1.6.*'
+          - '1.8.*'
+          - '1.10.*'
+          - '1.11.*'
     steps:
       - uses: actions/checkout@v3
         with:
@@ -47,6 +46,6 @@ jobs:
       - run: go mod download
       - env:
           PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
-          TF_ACC: "1"
+          TF_ACC: '1'
         run: go test -race -covermode=atomic -coverprofile=coverage.out -v ./pinecone/provider/
         timeout-minutes: 10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,8 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: true
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v3
       - run: go generate ./...
       - name: git diff
         run: |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,7 @@ linters:
   enable:
     - durationcheck
     - errcheck
-    - exportloopref
+    - copyloopvar
     - forcetypeassert
     - godot
     - gofmt
@@ -20,8 +20,8 @@ linters:
     - nilerr
     - predeclared
     - staticcheck
-    - tenv
+    - usetesting
     - unconvert
     - unparam
     - unused
-    - vet
+    - govet


### PR DESCRIPTION
## Problem
We're using the lowest versions of Terraform in our testing matrix, which is the default from the template: https://github.com/hashicorp/terraform-provider-scaffolding-framework/blob/58c457935f9f13b8cc5819c7ac86bef07626c9ff/.github/workflows/test.yml#L64

## Solution
- Bump the range of versions tested to more recent releases.
- Update `golangci.yml` to a more modern set of linting options.
- Fix issue with not installing terraform before running `go generate` in CI.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan